### PR TITLE
Add a 'skip' option and document the term_width parameter to the constructor

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl extension Term-ProgressBar.
 
+2.14
+    - Document the term_width argument to the constructor
+    - Add a "silent" option to the constructor
+
 2.13 Fri May 18 06:24:42 2012
 	- remove unused and invalid SIGNATURE file
 	- move content of BUGS to Changes

--- a/t/silent.t
+++ b/t/silent.t
@@ -1,0 +1,61 @@
+# (X)Emacs mode: -*- cperl -*-
+
+use strict;
+use warnings;
+use Term::ProgressBar;
+
+=head1 Unit Test Package for Term::ProgressBar
+
+This package tests the basic functionality of Term::ProgressBar.
+
+=cut
+
+use Test::More tests => 8;
+use Test::Exception;
+
+use Capture::Tiny qw(capture_stderr);
+
+my $MESSAGE1 = 'Walking on the Milky Way';
+
+# -------------------------------------
+
+=head2 Test
+
+Create a progress bar with 10 things.
+Update it it from 1 to 10.  Verify that it has no output.
+
+=cut
+{
+  my $err = capture_stderr {
+    my $p;
+    lives_ok { $p = Term::ProgressBar->new({ count => 10, silent => 1}); } 'Count 1-10 (1)';
+    lives_ok { $p->update($_) for 1..5  }         'Count 1-10 (2)';
+    lives_ok { $p->message($MESSAGE1)    }         'Count 1-10 (3)';
+    lives_ok { $p->update($_) for 6..10 }         'Count 1-10 (4)';
+  };
+
+  diag "ERR:\n$err\nlength: " . length($err)
+    if $ENV{TEST_DEBUG};
+  ok !$err, 'We should have no output';
+}
+
+# -------------------------------------
+
+=head2 Tests 9--11: Message Check
+
+Run a progress bar from 0 to 100, each time calling a message after an update.
+Check that we still have no output.
+
+=cut
+
+{
+  my $err = capture_stderr {
+    my $p;
+    lives_ok { $p = Term::ProgressBar->new({ count => 100, silent => 1}); } 'Message Check ( 1)';
+    lives_ok { for (0..100) { $p->update($_); $p->message("Hello") } }  'Message Check ( 2)';
+  };
+
+  ok !$err, 'We should sill have no output';
+}
+
+# ----------------------------------------------------------------------------


### PR DESCRIPTION
This pull request fixes a couple of minor issues I've had.

First, I've documented the 'term_width' argument to the constructor. I've had issues ssh'ing into a remote machine and then finding the term_width defaulting to 50 with a warning that it couldn't determine the terminal size. Digging through the source code helped me find this undocumented function.

Next, I sometimes find myself working on machines where Term::ProgressBar doesn't work due to issues with the underlying modules (can't recall the details right now), or I just want to easily silence the module with a switch. So I added the 'silent' option to the constructor. If passed a true value, then Term::ProgressBar does nothing, but you don't need to change any other code.
