### PR TITLE
Added support for cygwin

### DIFF
--- a/lib/Term/ProgressBar.pm
+++ b/lib/Term/ProgressBar.pm
@@ -298,7 +298,7 @@ sub term_size {
   my $result;
   eval {
     $result = (Term::ReadKey::GetTerminalSize($fh))[0];
-    $result-- if ($^O eq "MSWin32");
+    $result-- if ($^O eq "MSWin32" or $^O eq "cygwin");
   }; if ( $@ ) {
     warn "error from Term::ReadKey::GetTerminalSize(): $@";
   }


### PR DESCRIPTION
'cygwin' OS should be treated the same as 'MSWin32'

Under cygwin, $^O reports an OS of 'cygwin' instead of 'MSWin32', but still has the same mal-treatment of the terminal columns as other perl distributions for Windows. This tiny change fixes everything.
