### PR TITLE
Silent mode without undefined values warnings

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Term-ProgressBar
 
+2.18 2016-11-24
+   - silent mode avoids uninitialized value messages (GFIREBALL)
+
 2.17 2015-01-23
    - Handle case when the maximum number of items is unknown (LukeGoodsell)
 

--- a/lib/Term/ProgressBar.pm
+++ b/lib/Term/ProgressBar.pm
@@ -2,7 +2,7 @@ package Term::ProgressBar;
 use strict;
 use warnings;
 
-our $VERSION = '2.17';
+our $VERSION = '2.18';
 
 #XXX TODO Redo original test with count=20
 #         Amount Output
@@ -461,7 +461,6 @@ Class::MethodMaker->import (new_with_init => 'new',
 
 sub init {
   my $self = shift;
-  return if $self->silent;
 
   # V1 Compatibility
   return $self->init({count      => $_[1], name => $_[0],
@@ -682,7 +681,6 @@ Class::MethodMaker->import
 # We generate these by hand since we want to check the values.
 sub bar_width {
     my $self = shift;
-    return if $self->silent;
     return $self->{bar_width} if not @_;
     croak 'wrong number of arguments' if @_ != 1;
     croak 'bar_width < 1' if $_[0] < 1;
@@ -690,7 +688,6 @@ sub bar_width {
 }
 sub term_width {
     my $self = shift;
-    return if $self->silent;
     return $self->{term_width} if not @_;
     croak 'wrong number of arguments' if @_ != 1;
     croak 'term_width must be at least 5' if $self->term and $_[0] < 5;
@@ -699,7 +696,6 @@ sub term_width {
 
 sub target {
   my $self = shift;
-  return if $self->silent;
 
   if ( @_ ) {
     my ($target) = @_;
@@ -786,7 +782,10 @@ The next value of so_far at which to call C<update>.
 
 sub update {
   my $self = shift;
-  return if $self->silent;
+  # returning target+1 as next value should avoid calling update
+  # method in the smooth form of using the progress bar
+  return $self->target+1 if $self->silent;
+
   my ($so_far) = @_;
 
   if ( ! defined $so_far ) {

--- a/t/silent.t
+++ b/t/silent.t
@@ -19,7 +19,7 @@ my $MESSAGE1 = 'Walking on the Milky Way';
 
 # -------------------------------------
 
-=head2 Test
+=head2 Test 1--5
 
 Create a progress bar with 10 things.
 Update it it from 1 to 10.  Verify that it has no output.
@@ -41,7 +41,7 @@ Update it it from 1 to 10.  Verify that it has no output.
 
 # -------------------------------------
 
-=head2 Tests 9--11: Message Check
+=head2 Tests 6--8: Message Check
 
 Run a progress bar from 0 to 100, each time calling a message after an update.
 Check that we still have no output.

--- a/t/silent.t
+++ b/t/silent.t
@@ -59,3 +59,38 @@ Check that we still have no output.
 }
 
 # ----------------------------------------------------------------------------
+
+=head2 Tests 9--13: Message Check
+
+Run a progress bar from 0 to 1000, each time calling a message after an update.
+Check that we still have no output.
+
+=cut
+{
+  my $err = capture_stderr {
+    my $p;
+    my $max_value = 1000;
+    my $half_value = int($max_value/2);
+    lives_ok { $p = Term::ProgressBar->new({ count => $max_value, silent => 1}); } 'Count 1-1000 (1)';
+    my $next_value = 0;
+    lives_ok {
+      for (my $i=0; $i<$half_value; $i++)
+	{
+	  $next_value = $p->update($i) if ($i >= $next_value);
+	}
+    } 'Count 1-1000 (2)';
+    lives_ok { $p->message($MESSAGE1)    }         'Count 1-1000 (3)';
+    lives_ok {
+      for (my $i=$half_value; $i<$max_value; $i++)
+	{
+	  $next_value = $p->update($i) if ($i >= $next_value);
+	}
+    } 'Count 1-1000 (4)';
+  };
+
+  diag "ERR:\n$err\nlength: " . length($err)
+    if $ENV{TEST_DEBUG};
+  ok !$err, 'We should still have no output even with warnings enabled';
+}
+
+# ----------------------------------------------------------------------------

--- a/t/silent.t
+++ b/t/silent.t
@@ -10,7 +10,7 @@ This package tests the basic functionality of Term::ProgressBar.
 
 =cut
 
-use Test::More tests => 8;
+use Test::More tests => 13;
 use Test::Exception;
 
 use Capture::Tiny qw(capture_stderr);
@@ -55,7 +55,7 @@ Check that we still have no output.
     lives_ok { for (0..100) { $p->update($_); $p->message("Hello") } }  'Message Check ( 2)';
   };
 
-  ok !$err, 'We should sill have no output';
+  ok !$err, 'We should still have no output';
 }
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
This version avoids undefined values warnings in the [A much more efficient update](https://metacpan.org/pod/distribution/Term-ProgressBar/lib/Term/ProgressBar.pm#A-much-more-efficient-update)  examples without code changes.
